### PR TITLE
Fix: Correct text rendering and Wishlist navigation

### DIFF
--- a/Utils/Footer/Footer.tsx
+++ b/Utils/Footer/Footer.tsx
@@ -11,7 +11,7 @@ const Footer = () => {
 
   const tabs = [
     { name: 'Home', icon: 'home' },
-    { name: 'Wishlist', icon: 'heart' },
+    { name: 'WishlistScreen', icon: 'heart' },
     { name: 'Cart', icon: 'shopping-cart' },
     { name: 'Profile', icon: 'user' },
   ];

--- a/components/Homepage/Contentpage.tsx
+++ b/components/Homepage/Contentpage.tsx
@@ -52,7 +52,7 @@ const handelseall = (): void => {
       {/* Filter Section */}
       <View style={styles.filterContainer}>
         <Text style={styles.filterTitle}>
-          Filters{" "}
+          Filters<Text>{" "}</Text>
           <Ionicons
             name="funnel-outline"
             size={15}
@@ -77,7 +77,7 @@ const handelseall = (): void => {
         <TouchableOpacity onPress={(handelseall)}>
           <Text style={{ color: "blue" }}>See All</Text>
         </TouchableOpacity>
-      </View>{" "}
+      </View>
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}


### PR DESCRIPTION
- I resolved the 'Text strings must be rendered within a <Text> component' warning in Contentpage.tsx by removing an extraneous space and ensuring proper text wrapping.
- I fixed the 'NAVIGATE to Wishlist was not handled' error by updating the navigation call in Footer.tsx to use 'WishlistScreen' to match the navigator definition in App.tsx.